### PR TITLE
Required in header row

### DIFF
--- a/src/SheetToObjects.Lib/AttributesConfiguration/MappingTypeAttributes/RequiredInHeaderRow.cs
+++ b/src/SheetToObjects.Lib/AttributesConfiguration/MappingTypeAttributes/RequiredInHeaderRow.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using SheetToObjects.Lib.FluentConfiguration;
+
+namespace SheetToObjects.Lib.AttributesConfiguration.MappingTypeAttributes
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class RequiredInHeaderRow : Attribute
+    {
+        public void SetColumnMapping<T>(ColumnMappingBuilder<T> builder)
+        {
+            builder.WithRequiredInHeaderRow();
+        }
+    }
+}

--- a/src/SheetToObjects.Lib/FluentConfiguration/ColumnMappingBuilder.cs
+++ b/src/SheetToObjects.Lib/FluentConfiguration/ColumnMappingBuilder.cs
@@ -17,6 +17,7 @@ namespace SheetToObjects.Lib.FluentConfiguration
         private string _propertyName;
         private string _format;
         private object _defaultValue;
+        private bool _isRequiredInHeaderRow;
         private readonly List<IParsingRule> _parsingRules = new List<IParsingRule>();
         private readonly List<IRule> _rules = new List<IRule>();
 
@@ -34,7 +35,7 @@ namespace SheetToObjects.Lib.FluentConfiguration
         /// </summary>
         public ColumnMappingBuilder<T> WithColumnIndex(int columnIndex)
         {
-            _columnIndex = columnIndex; ;
+            _columnIndex = columnIndex;
             return this;
         }
 
@@ -56,7 +57,13 @@ namespace SheetToObjects.Lib.FluentConfiguration
             return this;
         }
 
-        /// <summary>
+        public ColumnMappingBuilder<T> WithRequiredInHeaderRow()
+        {
+            _isRequiredInHeaderRow = true;
+            return this;
+        }
+
+    /// <summary>
         /// Add new rule that the column needs to adhere to during parsing
         /// </summary>
         public ColumnMappingBuilder<T> AddParsingRule(IParsingRule rule)
@@ -138,13 +145,13 @@ namespace SheetToObjects.Lib.FluentConfiguration
             _propertyName = property.Name;
 
             if(_header.IsNotNullOrWhiteSpace())
-                return new NameColumnMapping(_header, _propertyName, _format, _parsingRules, _rules, _defaultValue);
+                return new NameColumnMapping(_header, _propertyName, _format, _parsingRules, _rules, _defaultValue,_isRequiredInHeaderRow);
             if(_columnLetter.IsNotNullOrWhiteSpace())
                 return new LetterColumnMapping(_columnLetter, _propertyName, _format, _parsingRules, _rules, _defaultValue);
             if(_columnIndex >= 0)
                 return new IndexColumnMapping(_columnIndex, _propertyName, _format, _parsingRules, _rules, _defaultValue);
 
-            return new PropertyColumnMapping(_propertyName, _format, _parsingRules, _rules, _defaultValue);
+            return new PropertyColumnMapping(_propertyName, _format, _parsingRules, _rules, _defaultValue,_isRequiredInHeaderRow);
         }
     }
 }

--- a/src/SheetToObjects.Lib/FluentConfiguration/IUseHeaderRow.cs
+++ b/src/SheetToObjects.Lib/FluentConfiguration/IUseHeaderRow.cs
@@ -4,6 +4,8 @@
     {
         string ColumnName { get; }
 
+        bool IsRequiredInHeaderRow { get; }
+
         void SetColumnIndex(int columnIndex);
     }
 }

--- a/src/SheetToObjects.Lib/FluentConfiguration/MappingConfigByAttributeCreator.cs
+++ b/src/SheetToObjects.Lib/FluentConfiguration/MappingConfigByAttributeCreator.cs
@@ -63,6 +63,9 @@ namespace SheetToObjects.Lib.FluentConfiguration
                         case var _ when attribute is DefaultValue:
                             mappingConfigBuilder.WithDefaultValue(((DefaultValue) attribute).Value);
                             break;
+                        case var _ when attribute is RequiredInHeaderRow:
+                            mappingConfigBuilder.WithRequiredInHeaderRow();
+                            break;
                     }
                 }
 

--- a/src/SheetToObjects.Lib/FluentConfiguration/NameColumnMapping.cs
+++ b/src/SheetToObjects.Lib/FluentConfiguration/NameColumnMapping.cs
@@ -7,11 +7,14 @@ namespace SheetToObjects.Lib.FluentConfiguration
     {
         public string ColumnName { get; }
 
-        public NameColumnMapping(string columnName, string propertyName, string format, List<IParsingRule> parsingRules, List<IRule> rules, object defaultValue) 
+        public bool IsRequiredInHeaderRow { get; }
+
+        public NameColumnMapping(string columnName, string propertyName, string format, List<IParsingRule> parsingRules, List<IRule> rules, object defaultValue, bool isRequiredInHeaderRow) 
             : base(propertyName, format, parsingRules, rules, defaultValue)
         {
             ColumnName = columnName;
             ColumnIndex = -1;
+            IsRequiredInHeaderRow = isRequiredInHeaderRow;
         }
 
         public void SetColumnIndex(int columnIndex)

--- a/src/SheetToObjects.Lib/FluentConfiguration/PropertyColumnMapping.cs
+++ b/src/SheetToObjects.Lib/FluentConfiguration/PropertyColumnMapping.cs
@@ -6,12 +6,14 @@ namespace SheetToObjects.Lib.FluentConfiguration
     internal class PropertyColumnMapping : ColumnMapping, IUseHeaderRow
     {
         public string ColumnName { get; }
+        public bool IsRequiredInHeaderRow { get; }
 
-        public PropertyColumnMapping(string propertyName, string format, List<IParsingRule> parsingRules, List<IRule> rules, object defaultValue) 
+        public PropertyColumnMapping(string propertyName, string format, List<IParsingRule> parsingRules, List<IRule> rules, object defaultValue, bool isRequiredInHeaderRow) 
             : base(propertyName, format, parsingRules, rules, defaultValue)
         {
             ColumnName = propertyName;
             ColumnIndex = -1;
+            IsRequiredInHeaderRow = isRequiredInHeaderRow;
         }
         public void SetColumnIndex(int columnIndex)
         {

--- a/src/SheetToObjects.Lib/Validation/ParsingValidationError.cs
+++ b/src/SheetToObjects.Lib/Validation/ParsingValidationError.cs
@@ -5,6 +5,7 @@
         private const string CellNotFoundMessage = "Cell not found";
         private const string CouldNotParseValueMessage = "Could not parse value";
         private const string ValueTypeCanNotBeNullMessage = "Value type can not be null";
+        private const string HeaderNotFoundMesage = "Could not find columname in headerrow";
 
         public string CellValue { get; }
         public string ColumnName { get; }
@@ -37,5 +38,13 @@
         {
             return new ParsingValidationError(columnIndex, rowIndex, columnName, propertyName, string.Empty, ValueTypeCanNotBeNullMessage);
         }
+
+        public static IValidationError CouldNotFindHeader(int columnIndex, int rowIndex, string columnName,string propertyName)
+        {
+            return new ParsingValidationError(columnIndex, rowIndex, columnName, propertyName, columnName, HeaderNotFoundMesage);
+        }
+
+
+
     }
 }

--- a/src/SheetToObjects.Specs/Lib/AttributeConfiguration/MappingConfigByAttributeCreatorSpecs.cs
+++ b/src/SheetToObjects.Specs/Lib/AttributeConfiguration/MappingConfigByAttributeCreatorSpecs.cs
@@ -81,5 +81,17 @@ namespace SheetToObjects.Specs.Lib.AttributeConfiguration
 
             columnMapping.DefaultValue.Should().Be(defaultValue);
         }
+
+        [Fact]
+        void WhenPropertyIsRequiredInHeaderRow_RequiredInHeaderRowIsSet()
+        {
+            var columnName = "RequiredInHeaderProperty";
+
+            var result = new MappingConfigByAttributeCreator<AttributeTestModel>().CreateMappingConfig();
+
+            var columnMapping = result.Value.ColumnMappings.Single(c => c.PropertyName.Equals(columnName)) as IUseHeaderRow;
+
+            columnMapping.IsRequiredInHeaderRow.Should().BeTrue();
+        }
     }
 }

--- a/src/SheetToObjects.Specs/Lib/Validation/SheetMapperValidationSpecs.cs
+++ b/src/SheetToObjects.Specs/Lib/Validation/SheetMapperValidationSpecs.cs
@@ -288,5 +288,54 @@ namespace SheetToObjects.Specs.Lib.Validation
             result.ValidationErrors.Single().RowIndex.Should().Be(2);
             result.ValidationErrors.Single().ColumnIndex.Should().Be(0);
         }
+
+        [Fact]
+        public void GivenValidatingWithIsRequiredInHeaderRow_WhenColumnIsInHeader_ItIsValid()
+        {
+
+            var sheetData = new SheetBuilder()
+                .AddHeaders("Column1")
+                .AddRow(r => r.AddCell(c => c.WithColumnIndex(0).WithRowIndex(1).WithValue(4).Build()).Build(1))
+                .AddRow(r => r.AddCell(c => c.WithColumnIndex(0).WithRowIndex(2).WithValue(12).Build()).Build(2))
+                .Build();
+
+            var result = new SheetMapper()
+                .AddConfigFor<TestModel>(cfg => cfg
+                    .HasHeaders()
+                    .MapColumn(column => column
+                        .WithHeader("Column1")
+                        .IsRequired()
+                        .WithRequiredInHeaderRow()
+                        .MapTo(t => t.IntProperty)))
+                .Map<TestModel>(sheetData);
+
+            result.IsSuccess.Should().BeTrue();
+            result.ValidationErrors.Should().HaveCount(0);
+        }
+
+        [Fact]
+        public void GivenValidatingWithIsRequiredInHeaderRow_WhenColumnIsNotInHeader_ItIsValid()
+        {
+
+            var sheetData = new SheetBuilder()
+                .AddHeaders("Column2")
+                .AddRow(r => r.AddCell(c => c.WithColumnIndex(0).WithRowIndex(1).WithValue(4).Build()).Build(1))
+                .AddRow(r => r.AddCell(c => c.WithColumnIndex(0).WithRowIndex(2).WithValue(12).Build()).Build(2))
+                .Build();
+
+            var result = new SheetMapper()
+                .AddConfigFor<TestModel>(cfg => cfg
+                    .HasHeaders()
+                    .MapColumn(column => column
+                        .WithHeader("Column1")
+                        .IsRequired()
+                        .WithRequiredInHeaderRow()
+                        .MapTo(t => t.IntProperty)))
+                .Map<TestModel>(sheetData);
+
+            result.IsSuccess.Should().BeFalse();
+            result.ValidationErrors.Should().HaveCount(1);
+            result.ValidationErrors.Single().PropertyName.Should().Be("Column1");
+        }
     }
 }

--- a/src/SheetToObjects.Specs/TestModels/AttributeTestModel.cs
+++ b/src/SheetToObjects.Specs/TestModels/AttributeTestModel.cs
@@ -19,5 +19,10 @@ namespace SheetToObjects.Specs.TestModels
         [Format("yyyy-MM-dd")]
         [IsRequired]
         public DateTime DateTimeProperty { get; set; }
+
+
+        [MappingByHeader("RequiredInHeaderProperty")]
+        [RequiredInHeaderRow]
+        public string RequiredInHeaderProperty { get; set; }
     }
 }


### PR DESCRIPTION
Added validation for the name/Property columnmappings to check presence in the headerrow

ColumnMappingBuilder.cs, had strange compare but added only:
 _isRequiredInHeaderRow; private property
WithRequiredInHeaderRow(): function
NameColumnMapping and PropertyColumnMapping