### PR TITLE
Added parameter stopReadingOnEmptyRow for Excel adapter

### DIFF
--- a/src/SheetToObjects.Adapters.MicrosoftExcel/IProvideSheet.cs
+++ b/src/SheetToObjects.Adapters.MicrosoftExcel/IProvideSheet.cs
@@ -5,7 +5,7 @@ namespace SheetToObjects.Adapters.MicrosoftExcel
 {
     public interface IProvideSheet
     {
-        Sheet GetFromPath(string excelPath, string sheetName, ExcelRange range);
-        Sheet GetFromStream(Stream fileStream, string sheetName, ExcelRange range);
+        Sheet GetFromPath(string excelPath, string sheetName, ExcelRange range, bool stopReadingOnEmptyRow = false);
+        Sheet GetFromStream(Stream fileStream, string sheetName, ExcelRange range, bool stopReadingOnEmptyRow = false);
     }
 }

--- a/src/SheetToObjects.Specs/Adapters/MicrosoftExcelProviderSpecs.cs
+++ b/src/SheetToObjects.Specs/Adapters/MicrosoftExcelProviderSpecs.cs
@@ -80,5 +80,28 @@ namespace SheetToObjects.Specs.Adapters
                 }
             }
         }
+
+        [Theory]        
+        [InlineData(true, 3)]
+        [InlineData(false, 1048576)]
+
+        public void GivenALargeNumberOfRows_WhenLoadingDataWithoutStopping_ReturnsMaxNumberOfRows(bool stopOnEmptyRow, int expectedCount)
+        {
+            int max_number_of_excel_rows = 1048576;
+
+            using (var fileStream = new FileStream(TwoColumnsTwoRowsWithHeadersFilePath, FileMode.Open))
+            {
+                using (var sr = new StreamReader(fileStream, Encoding.UTF8, false, 1024, true))
+                {
+                    var provider = new SheetProvider(new ExcelAdapter());
+                    var excelRange = new ExcelRange(new ExcelCell("A", 1), new ExcelCell("B", max_number_of_excel_rows));
+
+                    var csvData = provider.GetFromStream(sr.BaseStream, "my sheet", excelRange, stopOnEmptyRow);
+
+                    csvData.Rows.Count.Should().Be(expectedCount);
+                    csvData.Rows.First().Cells.Count.Should().Be(2);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
I added a parameter to the excel provider to stop reading the file when an empty row is "seen". This way one can prevent loading all given rows when no data is available below a certain row. 

Testing shows a serious drop in loading time when reading the maximum amount of rows (1048576).